### PR TITLE
Update Park command for Easylife GO

### DIFF
--- a/automower_ble/mower.py
+++ b/automower_ble/mower.py
@@ -140,6 +140,9 @@ class Mower(BLEClient):
     async def mower_park(self):
         await self.command("SetOverrideParkUntilNextStart")
 
+        # Request trigger to start, the response validation is expected to fail
+        await self.command("StartTrigger")
+
     async def get_task(self, taskid: int) -> TaskInformation | None:
         """
         Get information about a specific task


### PR DESCRIPTION
Park command needs await self.command("StartTrigger"), as does the overide.

For Easylife GO, the HA integration will need to accept/mandate the pin code for commands.